### PR TITLE
Enable the server to start without config.json

### DIFF
--- a/app.js
+++ b/app.js
@@ -10,6 +10,12 @@ nconf.argv()
      .env()
      .file({ file:'config.json'});
 
+nconf.defaults({
+  AUTH_ENABLED: false,
+  AUTH_JWT_SECRET: 'my-secret',
+  AUTH_JWT_TOKENTIME: 6000,
+});
+
 // set up Express and routes
 const express = require('express'),
       bodyParser = require('body-parser'),


### PR DESCRIPTION
I added default configuration values for JWT so that the server can start if the config.json file is missing. Currently, if the user starts the server without the config.json file, there is a cryptic error thrown related to the missing JWT secret.

The endpoint operations error appropriately if the database configuration is missing. 

E.g. GET /api/todo/active

```
{"error":"[DB ERROR] Error: Unable to acquire a connection"}
```